### PR TITLE
fix: bypass YouTube JS challenge using nodejs and impersonation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ It uses yt-dlp for downloading videos and a JSON based configuration file to def
 ## Requirements
 + Python 3.10+
 + yt-dlp
-+ FFmpeg (Optional but highly recommended)
++ Node.js [Installation](https://nodejs.org/en/download)
++ FFmpeg (Optional but highly recommended) [Installation](https://ffmpeg.org/download.html)
+
+Make sure that both Node.js and FFmpeg are in your PATH.
 
 ## Installation
 
 + ### Windows
-  + #### Install FFmpeg
-    Follow this [guide](https://www.geeksforgeeks.org/installation-guide/how-to-install-ffmpeg-on-windows/) to properly install FFmpeg on Windows.
   + #### Install `sync-yt`
     ```
     $ pip install sync-yt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Siddhesh Dharme", email = "siddheshdharme18@gmail.com"}
 ]
 description = "CLI tool to mirror YouTube playlists into local directories"
-dependencies = ["yt-dlp"]
+dependencies = ["yt-dlp","curl_cffi","yt-dlp-ejs"]
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/sync_yt/sync_yt.py
+++ b/src/sync_yt/sync_yt.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 
+
 def parse_config(config_path: Path):
 
     try:
@@ -59,11 +60,11 @@ def remove_from_archive(playlist_dir: Path, video_ids: list):
 def get_playlist(playlist_url: str, cookies_from_browser: str = None):
 
     yt_dlp_args = {
-        "extract_flat": "in_playlist", 
-        "quiet": True, 
+        "extract_flat": "in_playlist",
+        "quiet": True,
         "no_warnings": True,
-        "js_runtimes": {"node": {}},  #Force the use of Node.js
-        "impersonate": ImpersonateTarget(client="chrome")     #Disguise as a navigator
+        "js_runtimes": {"node": {}},  # Force the use of Node.js
+        "impersonate": ImpersonateTarget(client="chrome"),  # Disguise as a navigator
     }
     if cookies_from_browser is not None:
         yt_dlp_args["cookiesfrombrowser"] = (cookies_from_browser,)
@@ -110,8 +111,8 @@ def sync_playlist(
         "paths": {"home": playlist_dir},
         "ignoreerrors": "only_download",
         "quiet": True,
-        "js_runtimes": {"node": {}},  #Force the use of Node.js
-        "impersonate": ImpersonateTarget(client="chrome")     #Disguise as a navigator 
+        "js_runtimes": {"node": {}},  # Force the use of Node.js
+        "impersonate": ImpersonateTarget(client="chrome"),  # Disguise as a navigator
     }
 
     if cookies_from_browser is not None:

--- a/src/sync_yt/sync_yt.py
+++ b/src/sync_yt/sync_yt.py
@@ -1,9 +1,9 @@
 from yt_dlp import YoutubeDL
+from yt_dlp.networking.impersonate import ImpersonateTarget
 from pathlib import Path
 import json
 import os
 import re
-
 
 def parse_config(config_path: Path):
 
@@ -58,7 +58,13 @@ def remove_from_archive(playlist_dir: Path, video_ids: list):
 
 def get_playlist(playlist_url: str, cookies_from_browser: str = None):
 
-    yt_dlp_args = {"extract_flat": "in_playlist", "quiet": True, "no_warnings": True}
+    yt_dlp_args = {
+        "extract_flat": "in_playlist", 
+        "quiet": True, 
+        "no_warnings": True,
+        "js_runtimes": {"node": {}},  #Force the use of Node.js
+        "impersonate": ImpersonateTarget(client="chrome")     #Disguise as a navigator
+    }
     if cookies_from_browser is not None:
         yt_dlp_args["cookiesfrombrowser"] = (cookies_from_browser,)
 
@@ -104,6 +110,8 @@ def sync_playlist(
         "paths": {"home": playlist_dir},
         "ignoreerrors": "only_download",
         "quiet": True,
+        "js_runtimes": {"node": {}},  #Force the use of Node.js
+        "impersonate": ImpersonateTarget(client="chrome")     #Disguise as a navigator 
     }
 
     if cookies_from_browser is not None:


### PR DESCRIPTION
## Description
YouTube has recently tightened its anti-bot protections, causing `sync-yt` to fail when downloading formats that require signature deciphering (e.g., `bestaudio`).  That was causing the following errors:
- `Signature solving failed`
- `n challenge solving failed`

This PR fixes the issue by updating the `yt-dlp` configuration to properly handle the JS challenge and mimic a real browser footprint.

## Changes Proposed
- **Forced JS Runtime:** Explicitly added `"js_runtimes": {"node": {}}` to `yt_dlp_args` so `yt-dlp` correctly uses Node.js to solve YouTube's JavaScript challenges.
- **Client Impersonation:** Added `ImpersonateTarget(client="chrome")` to disguise the requests and bypass TLS fingerprinting blocks.
- **Dependencies Update:** Added `curl_cffi` to `pyproject.toml` (required by `yt-dlp` for the impersonation feature to work).

## Note to reviewer
Users will need to have Node.js installed on their system for the JS runtime to work properly, which is currently the recommended workaround by the `yt-dlp` team.