### PR TITLE
fix: convert thumbnails to jpg to support mp3 and m4a embedding

### DIFF
--- a/src/sync_yt/sync_yt.py
+++ b/src/sync_yt/sync_yt.py
@@ -137,6 +137,9 @@ def sync_playlist(
         # Embed thumbnail as a cover art if compatible format
         if preferred_codec in {"mp3", "m4a", "flac"}:
             postprocessors.append(
+                {"key": "FFmpegThumbnailsConvertor", "format": "jpg"}
+            )
+            postprocessors.append(
                 {"key": "EmbedThumbnail", "already_have_thumbnail": False}
             )
             yt_dlp_args["outtmpl"] = {"pl_thumbnail": ""}


### PR DESCRIPTION
## Description
Currently, sync-yt fails to embed cover art (thumbnails) into `.mp3` and `.m4a` files. This happens because YouTube now serves thumbnails in `.webp` format by default, which is incompatible with the strict metadata standards of MP3 and M4A containers (they require `.jpg` or `.png`). 

## Change Proposed
Forced the thumbnail format to `jpg` before passing it to `EmbedThumbnail`.